### PR TITLE
allow jade runtime to be omitted

### DIFF
--- a/src/webassets/filter/jade.py
+++ b/src/webassets/filter/jade.py
@@ -117,6 +117,8 @@ class Jade(Filter):
         if self.jade_runtime:
             with open(self.jade_runtime) as file:
                 runtime = ''.join(file.readlines())
+        else:
+            runtime = ''
 
         # JavaScript code to initialize the window-level object that will hold
         # our compiled Jade templates as functions


### PR DESCRIPTION
This allows the Jade runtime binary to be omitted from the options. This is useful when potentially including multiple Bundles of templates on the same page, and you only want to include runtime.js once.